### PR TITLE
Add features for backend selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 /.vscode/target/
+.cargo/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,13 @@ authors = ["Kumar Ankur <kmrankur@outlook.com>"]
 edition = "2018"
 
 [dependencies]
-amethyst = { git = "https://github.com/amethyst/amethyst", features = ["nightly", "metal", "json"] }
+amethyst = { git = "https://github.com/amethyst/amethyst", features = ["nightly", "json"] }
 serde = "*"
 log = "*"
 specs-derive = "*"
+
+[features]
+default = ["metal"]
+metal = ["amethyst/metal"]
+vulkan = ["amethyst/vulkan"]
+


### PR DESCRIPTION
This PR makes it so you can run with a different backend without having to patch Cargo.toml. This will make it for people to use git without accidentally adding backend selection changes.