### PR TITLE
Adding basic dying logic for marine

### DIFF
--- a/src/components/collision.rs
+++ b/src/components/collision.rs
@@ -160,6 +160,7 @@ pub struct Collider {
     pub on_ground: bool,
     pub hit_box_offset_front: f32,
     pub hit_box_offset_back: f32,
+    pub is_collidable: bool,
 }
 
 impl Default for Collider {
@@ -171,6 +172,7 @@ impl Default for Collider {
             on_ground: false,
             hit_box_offset_front: 0.,
             hit_box_offset_back: 0.,
+            is_collidable: true,
         }
     }
 }
@@ -184,6 +186,7 @@ impl Collider {
             on_ground: false,
             hit_box_offset_front: 0.,
             hit_box_offset_back: 0.,
+            is_collidable: true,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,11 @@ fn main() -> amethyst::Result<()> {
             &["collision_system"],
         )
         .with(
+            MarineCollisionSystem,
+            "marine_collision_system",
+            &["collision_system"],
+        )
+        .with(
             TransformationSystem,
             "transformation_system",
             &["pincer_collision_system", "bullet_collision_system"],

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -5,7 +5,7 @@ use amethyst::{
 
 use crate::{
     components::{
-        Boundary, Bullet, Collidee, CollideeDetails, Collider, Direction, Directions, Motion,
+        Boundary, Bullet, Collidee, CollideeDetails, Collider, Direction, Directions, Marine, MarineState, Motion,
         Pincer,
     },
     entities::{show_bullet_impact, show_explosion},
@@ -36,7 +36,7 @@ impl<'s> System<'s> for CollisionSystem {
             let half_size_a_x = bbox_a.half_size.x;
             let correction;
 
-            if velocity_a.x != 0. || velocity_a.y != 0. {
+            if velocity_a.x != 0. || velocity_a.y != 0. && collider_a.is_collidable {
                 for (entity_b, collider_b, motion_b, name_b) in
                     (&entities, &colliders, &motions, &names).join()
                 {
@@ -223,6 +223,31 @@ impl<'s> System<'s> for BulletCollisionSystem {
                     }
                 }
                 let _ = entities.delete(entity);
+            }
+        }
+    }
+}
+
+pub struct MarineCollisionSystem;
+
+impl<'s> System<'s> for MarineCollisionSystem {
+    type SystemData = (
+        ReadStorage<'s, Marine>,
+        WriteStorage<'s, Collider>,
+        ReadStorage<'s, Collidee>,
+    );
+    
+    fn run(&mut self, data: Self::SystemData) {
+        let (marines, mut colliders, collidees) = data;
+
+        for (marine, collider, collidee) in (&marines, &mut colliders, &collidees,).join() {
+            if let Some(collidee_horizontal) = &collidee.horizontal {
+                match collidee_horizontal.name.as_ref() {
+                    "Pincer" => {
+                        collider.is_collidable = false;
+                    }
+                    _ => {}
+                }
             }
         }
     }

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -24,7 +24,9 @@ impl<'s> System<'s> for MarineInputSystem {
             let shoot_input = input.action_is_down("shoot").expect("Shoot action exists");
 
             // TODO: check simultaneous button press
-            marine.state = if jump_input || !collider.on_ground {
+            marine.state = if !collider.is_collidable {
+                MarineState::Dying
+            } else if jump_input || !collider.on_ground {
                 MarineState::Jumping
             } else if run_input > 0. {
                 dir.x = Directions::Right;

--- a/src/systems/kinematics.rs
+++ b/src/systems/kinematics.rs
@@ -60,6 +60,14 @@ impl<'s> System<'s> for MarineKinematicsSystem {
                     let acceleration_x = if motion.velocity.x != 0. { -0.06 } else { 0. };
                     acceleration = Vector2::new(acceleration_x, -0.6);
                 }
+                MarineState::Dying => {
+                    if collider.on_ground {
+                        motion.velocity.x = 0.;
+                        motion.velocity.y = 8.;
+                        collider.on_ground = false;
+                    }
+                    acceleration = Vector2::new(0., -0.6);
+                }
                 _ => {}
             }
             motion.update_velocity(acceleration, dir, 0., marine.max_ground_speed);

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -15,6 +15,7 @@ pub use self::animation::PincerAnimationSystem;
 pub use self::attack::AttackSystem;
 pub use self::collision::BulletCollisionSystem;
 pub use self::collision::CollisionSystem;
+pub use self::collision::MarineCollisionSystem;
 pub use self::collision::PincerCollisionSystem;
 pub use self::direction::DirectionSystem;
 pub use self::input::MarineInputSystem;


### PR DESCRIPTION
Very basic dying logic, where marine dies as soon as it collides horizontally with pincer. Entity deletion logic not included. Also, the logic might have to be modified later on, so that the marine dies only when it collides with the pincer from the front.