### PR TITLE
Improve shooting control

### DIFF
--- a/src/systems/attack.rs
+++ b/src/systems/attack.rs
@@ -44,10 +44,7 @@ impl<'s> System<'s> for AttackSystem {
 
             // Currently shooting is possible only when marine is static
             if marine.state == MarineState::Shooting
-                && collider.on_ground
-                && motion.velocity.x == 0.
-                && !marine.is_shooting
-            {
+                && !marine.is_shooting {
                 marine.is_shooting = true;
 
                 let mut shoot_start_position = 0.;

--- a/src/systems/attack.rs
+++ b/src/systems/attack.rs
@@ -43,8 +43,7 @@ impl<'s> System<'s> for AttackSystem {
             let shoot_input = input.action_is_down("shoot").expect("shoot action exists");
 
             // Currently shooting is possible only when marine is static
-            if marine.state == MarineState::Shooting
-                && !marine.is_shooting {
+            if marine.state == MarineState::Shooting && !marine.is_shooting {
                 marine.is_shooting = true;
 
                 let mut shoot_start_position = 0.;

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -5,8 +5,8 @@ use amethyst::{
 
 use crate::{
     components::{
-        Boundary, Bullet, Collidee, CollideeDetails, Collider, Direction, Directions, Marine, MarineState, Motion,
-        Pincer,
+        Boundary, Bullet, Collidee, CollideeDetails, Collider, Direction, Directions, Marine,
+        MarineState, Motion, Pincer,
     },
     entities::{show_bullet_impact, show_explosion},
     resources::{AssetType, Context, PrefabList},
@@ -236,11 +236,11 @@ impl<'s> System<'s> for MarineCollisionSystem {
         WriteStorage<'s, Collider>,
         ReadStorage<'s, Collidee>,
     );
-    
+
     fn run(&mut self, data: Self::SystemData) {
         let (marines, mut colliders, collidees) = data;
 
-        for (marine, collider, collidee) in (&marines, &mut colliders, &collidees,).join() {
+        for (marine, collider, collidee) in (&marines, &mut colliders, &collidees).join() {
             if let Some(collidee_horizontal) = &collidee.horizontal {
                 match collidee_horizontal.name.as_ref() {
                     "Pincer" => {

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -34,9 +34,7 @@ impl<'s> System<'s> for MarineInputSystem {
             } else if run_input < 0. {
                 dir.x = Directions::Left;
                 MarineState::Running
-            } else if shoot_input
-                && marine.state != MarineState::Shooting
-                && !marine.is_shooting {
+            } else if shoot_input && marine.state != MarineState::Shooting && !marine.is_shooting {
                 MarineState::Shooting
             } else {
                 MarineState::Idling

--- a/src/systems/input.rs
+++ b/src/systems/input.rs
@@ -34,7 +34,9 @@ impl<'s> System<'s> for MarineInputSystem {
             } else if run_input < 0. {
                 dir.x = Directions::Left;
                 MarineState::Running
-            } else if shoot_input {
+            } else if shoot_input
+                && marine.state != MarineState::Shooting
+                && !marine.is_shooting {
                 MarineState::Shooting
             } else {
                 MarineState::Idling


### PR DESCRIPTION
Despite comment states marine should be static to shoot, it still has
a few bugs out there. This PR fix those bugs and make marine to shoot if
he is static for sure. Some condition checks are also removed since they
might not be needed to actually do the check. If users hold the action,
shooting state will be active only if the marine stop moving.

PS. I know I should do `cargo fmt` but it seems it's in another PR. Could I
just do it anyways?