### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/components/collision.rs
+++ b/src/components/collision.rs
@@ -115,10 +115,8 @@ impl Collidee {
 
         let same_direction = velocity_a.x * velocity_b.x > 0.;
         let faster = speed_ratio_a.x.abs() > speed_ratio_b.x.abs();
-        if !x_overlapped && y_overlapped
-            || (!x_overlapped && !y_overlapped && overlap.x.abs() <= overlap.y.abs())
-        {
-            if !same_direction || same_direction && faster {
+        if (y_overlapped || overlap.x.abs() <= overlap.y.abs()) && !x_overlapped {
+            if faster || !same_direction {
                 correction.x = overlap.x * speed_ratio_a.x;
             }
             // No correction (correction = 0.) is required if collider is slower
@@ -134,7 +132,7 @@ impl Collidee {
             // As per the current game design, no correction (correction = 0.) is required for this scenario
             // This might have to be changed in future
             self.horizontal = Some(CollideeDetails {
-                name: name.clone(),
+                name,
                 position: box_b.position,
                 half_size: box_b.half_size,
                 correction: correction.x,
@@ -190,7 +188,7 @@ impl Collider {
         }
     }
 
-    pub fn set_hit_box_position(&mut self, velocity: &Vector2<f32>) {
+    pub fn set_hit_box_position(&mut self, velocity: Vector2<f32>) {
         let hbox_position = &mut self.hit_box.position;
         let bbox_position = self.bounding_box.position;
         hbox_position.x = if velocity.x >= 0. {
@@ -211,14 +209,9 @@ impl Collider {
         } else {
             (&self.bounding_box, &other.bounding_box)
         };
-        if (self_box.position.x - other_box.position.x).abs()
+        !((self_box.position.x - other_box.position.x).abs()
             >= (self_box.half_size.x + other_box.half_size.x).abs()
             || (self_box.position.y - other_box.position.y).abs()
-                >= (self_box.half_size.y + other_box.half_size.y).abs()
-        {
-            false
-        } else {
-            true
-        }
+                >= (self_box.half_size.y + other_box.half_size.y).abs())
     }
 }

--- a/src/components/direction.rs
+++ b/src/components/direction.rs
@@ -1,5 +1,7 @@
 use amethyst::ecs::{Component, DenseVecStorage};
 
+// Remove this allow annotation when the Up and Down variants are taken in use.
+#[allow(dead_code)]
 #[derive(PartialEq, Clone, Copy)]
 pub enum Directions {
     Right,

--- a/src/entities/bullet.rs
+++ b/src/entities/bullet.rs
@@ -58,14 +58,14 @@ pub fn spawn_bullet(
     let mut collider = Collider::new(22. * scale, 4. * scale);
     let bbox = &mut collider.bounding_box;
     bbox.position = Vector2::new(bullet_start_position, marine_bottom + 48.);
-    bbox.old_position = bbox.position.clone();
+    bbox.old_position = bbox.position;
 
     transform.set_translation_x(bullet_start_position);
     transform.set_translation_y(marine_bottom + 48.);
     // bullet should be shown only after making sure that there is no collision at the spawn position
     transform.set_translation_z(-60.);
 
-    collider.set_hit_box_position(&motion.velocity);
+    collider.set_hit_box_position(motion.velocity);
 
     lazy_update.insert(bullet_entity, Bullet::default());
     lazy_update.insert(bullet_entity, Named::new("Bullet"));
@@ -101,14 +101,13 @@ pub fn show_bullet_impact(
         Directions::Neutral,
     );
 
-    let impact_position_x;
-    if bullet_velocity > 0. {
+    let impact_position_x = if bullet_velocity > 0. {
         direction.x = Directions::Right;
-        impact_position_x = impact_position - (8. * scale);
+        scale.mul_add(-8., impact_position)
     } else {
         direction.x = Directions::Left;
-        impact_position_x = impact_position + (8. * scale);
-    }
+        scale.mul_add(8., impact_position)
+    };
 
     let mut transform = Transform::default();
     transform.set_scale(Vector3::new(scale, scale, scale));

--- a/src/entities/explosion.rs
+++ b/src/entities/explosion.rs
@@ -23,7 +23,7 @@ pub fn show_explosion(
 
     let mut transform = Transform::default();
     transform.set_scale(Vector3::new(scale, scale, scale));
-    transform.set_translation_xyz(transform_x, transform_y + (32. - 15.) * scale, 0.);
+    transform.set_translation_xyz(transform_x, scale.mul_add(32. - 15., transform_y), 0.);
 
     lazy_update.insert(exposion_entity, Explosion::default());
     lazy_update.insert(

--- a/src/entities/marine.rs
+++ b/src/entities/marine.rs
@@ -27,10 +27,10 @@ pub fn load_marine(world: &mut World, prefab: Handle<Prefab<AnimationPrefabData>
     let mut collider = Collider::new(32. * scale, 36. * scale);
     let bbox = &mut collider.bounding_box;
     bbox.position = Vector2::new(384., 176.);
-    bbox.old_position = bbox.position.clone();
+    bbox.old_position = bbox.position;
 
     let motion = Motion::new();
-    collider.set_hit_box_position(&motion.velocity);
+    collider.set_hit_box_position(motion.velocity);
 
     world
         .create_entity()

--- a/src/entities/pincer.rs
+++ b/src/entities/pincer.rs
@@ -29,14 +29,14 @@ pub fn load_pincer(world: &mut World, prefab: Handle<Prefab<AnimationPrefabData>
 
     let bbox = &mut collider.bounding_box;
     bbox.position = Vector2::new(1040., 16.);
-    bbox.old_position = bbox.position.clone();
+    bbox.old_position = bbox.position;
 
     transform.set_translation_x(1040.);
     transform.set_translation_y(16.);
 
     let mut motion = Motion::new();
     motion.velocity.x = -3.;
-    collider.set_hit_box_position(&motion.velocity);
+    collider.set_hit_box_position(motion.velocity);
 
     let direction = Direction::new(
         Directions::Left,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+// Nearly every Amethyst system triggers this warning, better ignore it:
+#![allow(clippy::type_complexity)]
 extern crate amethyst;
 
 #[macro_use]

--- a/src/resources/map.rs
+++ b/src/resources/map.rs
@@ -90,10 +90,10 @@ impl Map {
             let mut collider = Collider::new(obj.width * scale, obj.height * scale);
             let bbox = &mut collider.bounding_box;
             bbox.position = Vector2::new(
-                obj.x * scale + ctx.x_correction + bbox.half_size.x,
+                scale.mul_add(obj.x, ctx.x_correction + bbox.half_size.x),
                 ctx.bg_height * 2. - (obj.y * scale) + ctx.y_correction - bbox.half_size.y,
             );
-            bbox.old_position = bbox.position.clone();
+            bbox.old_position = bbox.position;
 
             world
                 .create_entity()
@@ -147,20 +147,17 @@ impl Map {
                     sprite_number: 0,
                 };
 
-                match sprite_index_prop {
-                    Some(prop) => {
-                        sprite = SpriteRender {
-                            sprite_sheet: sprite_sheet_handle.clone(),
-                            sprite_number: prop.value,
-                        };
-                    }
-                    None => {}
+                if let Some(prop) = sprite_index_prop {
+                    sprite = SpriteRender {
+                        sprite_sheet: sprite_sheet_handle.clone(),
+                        sprite_number: prop.value,
+                    };
                 }
 
                 match layer.name.as_ref() {
                     "background" | "truss" => {
                         transform.set_translation_xyz(
-                            (obj.x + obj.width / 2.) * scale + x_correction,
+                            (obj.x + obj.width / 2.).mul_add(scale, x_correction),
                             ctx.bg_height * 2. - (obj.y + obj.height / 2.),
                             z_translation,
                         );
@@ -175,7 +172,7 @@ impl Map {
                     }
                     "platform" => {
                         transform.set_translation_xyz(
-                            (obj.x + obj.width / 2.) * scale + x_correction,
+                            (obj.x + obj.width / 2.).mul_add(scale, x_correction),
                             ctx.bg_height * 2. - (obj.y + obj.height / 2.) * scale
                                 + ctx.y_correction,
                             z_translation,

--- a/src/states/load.rs
+++ b/src/states/load.rs
@@ -57,7 +57,7 @@ impl SimpleState for LoadState {
                     let map_handle = &self.map_handle.take().unwrap();
                     map_storage.get(map_handle).unwrap().clone()
                 };
-                let ctx = data.world.read_resource::<Context>().clone();
+                let ctx = *data.world.read_resource::<Context>();
 
                 map.load_layers(data.world, &ctx);
 

--- a/src/systems/animation.rs
+++ b/src/systems/animation.rs
@@ -185,10 +185,8 @@ impl<'s> System<'s> for MarineAnimationSystem {
                 animation_control_set.start(new_animation_id);
 
                 animation.current = new_animation_id;
-            } else {
-                if new_animation_id == AnimationId::Die {
-                    animation.show = false;
-                }
+            } else if new_animation_id == AnimationId::Die {
+                animation.show = false;
             }
         }
     }

--- a/src/systems/attack.rs
+++ b/src/systems/attack.rs
@@ -37,7 +37,7 @@ impl<'s> System<'s> for AttackSystem {
             ctx,
         ) = data;
 
-        for (mut marine, motion, collider, direction) in
+        for (mut marine, _, collider, direction) in
             (&mut marines, &motions, &colliders, &directions).join()
         {
             let shoot_input = input.action_is_down("shoot").expect("shoot action exists");

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -6,7 +6,7 @@ use amethyst::{
 use crate::{
     components::{
         Boundary, Bullet, Collidee, CollideeDetails, Collider, Direction, Directions, Marine,
-        MarineState, Motion, Pincer, PincerAi,
+        Motion, Pincer, PincerAi,
     },
     entities::{show_bullet_impact, show_explosion},
     resources::{AssetType, Context, PrefabList},
@@ -71,7 +71,7 @@ impl<'s> System<'s> for CollisionSystem {
                     name: String::from("Boundary"),
                     position: Vector2::new(0., 0.),
                     half_size: Vector2::new(0., 0.),
-                    correction: correction,
+                    correction,
                 });
             }
         }
@@ -244,13 +244,10 @@ impl<'s> System<'s> for MarineCollisionSystem {
     fn run(&mut self, data: Self::SystemData) {
         let (marines, mut colliders, collidees) = data;
 
-        for (marine, collider, collidee) in (&marines, &mut colliders, &collidees).join() {
+        for (_, collider, collidee) in (&marines, &mut colliders, &collidees).join() {
             if let Some(collidee_horizontal) = &collidee.horizontal {
-                match collidee_horizontal.name.as_ref() {
-                    "Pincer" => {
-                        collider.is_collidable = false;
-                    }
-                    _ => {}
+                if let "Pincer" = collidee_horizontal.name.as_ref() {
+                    collider.is_collidable = false;
                 }
             }
         }

--- a/src/systems/kinematics.rs
+++ b/src/systems/kinematics.rs
@@ -1,6 +1,6 @@
 use amethyst::{
-    core::{math::Vector2, timing::Time},
-    ecs::{Join, Read, ReadStorage, System, WriteStorage},
+    core::math::Vector2,
+    ecs::{Join, ReadStorage, System, WriteStorage},
 };
 
 use crate::components::{Collider, Direction, Marine, MarineState, Motion};
@@ -15,13 +15,13 @@ impl<'s> System<'s> for KinematicsSystem {
 
         for (collider, motion) in (&mut colliders, &motions).join() {
             let bbox = &mut collider.bounding_box;
-            bbox.old_position = bbox.position.clone();
+            bbox.old_position = bbox.position;
             bbox.position.x += motion.velocity.x;
             bbox.position.y += motion.velocity.y;
 
             let hbox = &mut collider.hit_box;
-            hbox.old_position = hbox.position.clone();
-            collider.set_hit_box_position(&motion.velocity);
+            hbox.old_position = hbox.position;
+            collider.set_hit_box_position(motion.velocity);
         }
     }
 }
@@ -34,7 +34,6 @@ impl<'s> System<'s> for MarineKinematicsSystem {
         ReadStorage<'s, Direction>,
         ReadStorage<'s, Marine>,
         WriteStorage<'s, Motion>,
-        // Read<'s, Time>,
     );
 
     fn run(&mut self, data: Self::SystemData) {

--- a/src/systems/pincer.rs
+++ b/src/systems/pincer.rs
@@ -68,7 +68,7 @@ impl<'s> System<'s> for PincerAiSystem {
 
             // Give pincer a red tint if they are attacking, or no tint if they're not.
             tint.0 = match pincer.ai {
-                PincerAi::Attacking { target: _ } => Srgba::new(1.0, 0.0, 0.0, 1.0),
+                PincerAi::Attacking { .. } => Srgba::new(1.0, 0.0, 0.0, 1.0),
                 _ => Srgba::new(1.0, 1.0, 1.0, 1.0),
             };
         }

--- a/src/systems/transformation.rs
+++ b/src/systems/transformation.rs
@@ -32,24 +32,24 @@ impl<'s> System<'s> for TransformationSystem {
             let bbox = &mut collider.bounding_box;
             let velocity = &mut motion.velocity;
 
-            if collidee.horizontal.is_some() {
-                let collidee_horizontal = collidee.horizontal.take().unwrap();
+            if let Some(collidee_horizontal) = collidee.horizontal.take() {
                 bbox.position.x -= collidee_horizontal.correction;
             }
-            if collidee.vertical.is_some() {
-                let collidee_vertical = collidee.vertical.take().unwrap();
+            if let Some(collidee_vertical) = collidee.vertical.take() {
                 bbox.position.y -= collidee_vertical.correction;
                 velocity.y = 0.;
                 if collidee_vertical.correction < 0. {
                     collider.on_ground = true;
                 }
             }
+            // FIXME: Due to the take() operation above, collidee.vertical will always be NONE.
+            // Might indicate a bug.
             if collidee.vertical.is_none() && velocity.y != 0. {
                 collider.on_ground = false;
             }
             transform.set_translation_x(bbox.position.x);
             transform.set_translation_y(bbox.position.y);
-            collider.set_hit_box_position(velocity);
+            collider.set_hit_box_position(*velocity);
         }
     }
 }


### PR DESCRIPTION
This commit should not change any functionality, but only implements changes suggested by clippy. This commit also adds some #[allow(clippy:*)] annotations where necessary.

By keeping the clippy output clean, we can now rely on its output to pertain only to the most recently made changes. Which means we can use clippy to evaluate the code we just wrote.