### PR TITLE
Adding a system that checks death conditions for the marine

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,11 @@ fn main() -> amethyst::Result<()> {
             &["transformation_system"],
         )
         .with(
+            MarineDeathSystem,
+            "marine_death_system",
+            &["transformation_system"],
+        )
+        .with(
             CameraTransformationSystem,
             "camera_transformation_system",
             &["transformation_system"],

--- a/src/systems/death.rs
+++ b/src/systems/death.rs
@@ -1,0 +1,25 @@
+use amethyst::{
+    core::Transform,
+    ecs::{Entities, Join, ReadStorage, System},
+};
+
+use crate::components::Marine;
+
+pub struct MarineDeathSystem;
+
+impl<'s> System<'s> for MarineDeathSystem {
+    type SystemData = (
+        Entities<'s>,
+        ReadStorage<'s, Marine>,
+        ReadStorage<'s, Transform>,
+    );
+
+    fn run(&mut self, data: Self::SystemData) {
+        let (entities, marines, transforms) = data;
+        for (entity, _, transform) in (&entities, &marines, &transforms).join() {
+            if transform.translation().y < -999. {
+                let _ = entities.delete(entity);
+            }
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,6 +1,7 @@
 mod animation;
 mod attack;
 mod collision;
+mod death;
 mod direction;
 mod input;
 mod kinematics;
@@ -19,6 +20,7 @@ pub use self::collision::BulletCollisionSystem;
 pub use self::collision::CollisionSystem;
 pub use self::collision::MarineCollisionSystem;
 pub use self::collision::PincerCollisionSystem;
+pub use self::death::MarineDeathSystem;
 pub use self::direction::DirectionSystem;
 pub use self::input::MarineInputSystem;
 pub use self::kinematics::KinematicsSystem;


### PR DESCRIPTION
This could be a way of addressing #39 but there might be a better one (and for sure the present commit has to be improved in many respects).
At the present time, the idea is to check when the marine entity goes out of sight (since both falling and dying because of a collision with a Pincer move the marine out of the screen from the bottom).
