### PR TITLE
Fixed scaling issue after Amethyst upgrade & removed unneeded bg tiles

### DIFF
--- a/assets/tilemaps/map.json
+++ b/assets/tilemaps/map.json
@@ -84,42 +84,6 @@
                     "width": 384,
                     "x": 1920,
                     "y": 352
-                },
-                {
-                    "height": 16,
-                    "id": 23,
-                    "name": "",
-                    "properties": [],
-                    "rotation": 0,
-                    "type": "",
-                    "visible": true,
-                    "width": 16,
-                    "x": 1290.5,
-                    "y": 198
-                },
-                {
-                    "height": 0,
-                    "id": 24,
-                    "name": "",
-                    "properties": [],
-                    "rotation": 0,
-                    "type": "",
-                    "visible": true,
-                    "width": 0,
-                    "x": 1078.5,
-                    "y": 250.5
-                },
-                {
-                    "height": 16,
-                    "id": 27,
-                    "name": "",
-                    "properties": [],
-                    "rotation": 0,
-                    "type": "",
-                    "visible": true,
-                    "width": 16,
-                    "x": 1563,
-                    "y": 230
                 }
             ],
             "opacity": 1,

--- a/assets/tilemaps/map.tmx
+++ b/assets/tilemaps/map.tmx
@@ -9,9 +9,6 @@
   <object id="11" gid="2" x="1152" y="352" width="384" height="352"/>
   <object id="12" gid="2" x="1536" y="352" width="384" height="352"/>
   <object id="13" gid="2" x="1920" y="352" width="384" height="352"/>
-  <object id="23" x="1290.5" y="198" width="16" height="16"/>
-  <object id="24" x="1078.5" y="250.5"/>
-  <object id="27" x="1563" y="230" width="16" height="16"/>
  </objectgroup>
  <objectgroup id="4" name="truss">
   <object id="9" gid="1" x="0" y="352" width="832" height="352"/>

--- a/resources/display_config.ron
+++ b/resources/display_config.ron
@@ -2,5 +2,6 @@
   title: "space-menace",
   // dimensions: Some((768, 352)),
   // dimensions: Some((1536, 704)),
-  dimensions: Some((1200, 704)),
+  /* dimensions: Some((1200, 704)), */
+  dimensions: Some((600, 352)),
 )


### PR DESCRIPTION
This fixes the scaling issue that was observed after upgrading Amethyst. Also, fixes an existing issue of unneeded tiles messing up the background.